### PR TITLE
fix: handle undefined values in workspace options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "0f883bd8eae4dfc8019d925ec3dd04b634b6af9346a5168acc259d55f5f5021d"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_media_type",
  "deno_terminal",
  "dprint-swc-ext",
@@ -468,9 +468,9 @@ dependencies = [
  "cache_control",
  "chrono",
  "data-url",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_media_type",
- "deno_path_util 0.4.0",
+ "deno_path_util",
  "http",
  "indexmap",
  "log",
@@ -486,19 +486,19 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.54.2"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a3ff33a35a2e995bfea372cbe9fe0990a735e27988a787277a1c6ee15d1b1a"
+checksum = "a3949619345af4e06c803af7a4347083104651f67e6313810f09a15c0798a72c"
 dependencies = [
  "boxed_error",
  "capacity_builder",
- "deno_error 0.5.7",
- "deno_package_json 0.6.0",
- "deno_path_util 0.3.3",
- "deno_semver 0.7.1",
+ "deno_error",
+ "deno_package_json",
+ "deno_path_util",
+ "deno_semver",
  "glob",
  "ignore",
- "import_map 0.21.0",
+ "import_map",
  "indexmap",
  "jsonc-parser",
  "log",
@@ -508,46 +508,6 @@ dependencies = [
  "serde_json",
  "sys_traits",
  "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_config"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0804c8e7d732b962cb1a5543a79b1a1edd76dcf322656dd5cb540b79166e185d"
-dependencies = [
- "boxed_error",
- "capacity_builder",
- "deno_error 0.6.1",
- "deno_package_json 0.7.0",
- "deno_path_util 0.4.0",
- "deno_semver 0.8.0",
- "glob",
- "ignore",
- "import_map 0.22.0",
- "indexmap",
- "jsonc-parser",
- "log",
- "percent-encoding",
- "phf",
- "serde",
- "serde_json",
- "sys_traits",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_error"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e983933fb4958fbe1e0a63c1e89a2af72b12c409e86404e547955564e6e217b8"
-dependencies = [
- "deno_error_macro 0.5.7",
- "libc",
- "serde",
- "serde_json",
  "url",
 ]
 
@@ -557,23 +517,12 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612ec3fc481fea759141b0c57810889b0a4fb6fee8f10748677bfe492fd30486"
 dependencies = [
- "deno_error_macro 0.6.1",
+ "deno_error_macro",
  "libc",
  "serde",
  "serde_json",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "deno_error_macro"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ad5ae3ef15db33e917d6ed54b53d0a98d068c4d1217eb35a4997423203c3ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -597,14 +546,14 @@ dependencies = [
  "capacity_builder",
  "data-url",
  "deno_ast",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_media_type",
- "deno_path_util 0.4.0",
- "deno_semver 0.8.0",
+ "deno_path_util",
+ "deno_semver",
  "deno_unsync",
  "encoding_rs",
  "futures",
- "import_map 0.22.0",
+ "import_map",
  "indexmap",
  "log",
  "monch",
@@ -622,12 +571,12 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b66d23224880993944b71a6f552ba14e1bd61b63909ecad45eaff988b6bc90f"
+checksum = "7608e79ea3c0aef4860fb2f7319f1b98d0eeb4562df566e8099e5051886e2f95"
 dependencies = [
  "async-trait",
- "deno_semver 0.8.0",
+ "deno_semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -647,15 +596,15 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bac919755882524e95f2ed8b1770c1d95265a82d9a1db3fb004efa8c226fc8e"
+checksum = "536a02c258d4a3fcbbbb898562e230bbe5939ac2eb7c2058718508304e4ab7cf"
 dependencies = [
  "async-trait",
  "capacity_builder",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_lockfile",
- "deno_semver 0.8.0",
+ "deno_semver",
  "futures",
  "indexmap",
  "log",
@@ -674,10 +623,10 @@ dependencies = [
  "base64 0.22.1",
  "boxed_error",
  "deno_cache_dir",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_npm",
- "deno_path_util 0.4.0",
- "deno_semver 0.8.0",
+ "deno_path_util",
+ "deno_semver",
  "deno_unsync",
  "faster-hex",
  "flate2",
@@ -705,16 +654,16 @@ dependencies = [
  "bincode",
  "boxed_error",
  "capacity_builder",
- "deno_config 0.55.0",
- "deno_error 0.6.1",
+ "deno_config",
+ "deno_error",
  "deno_graph",
  "deno_lockfile",
  "deno_npm",
  "deno_npm_cache",
- "deno_package_json 0.7.0",
- "deno_path_util 0.4.0",
+ "deno_package_json",
+ "deno_path_util",
  "deno_resolver",
- "deno_semver 0.8.0",
+ "deno_semver",
  "deno_terminal",
  "deno_unsync",
  "futures",
@@ -735,48 +684,17 @@ dependencies = [
 
 [[package]]
 name = "deno_package_json"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236bc2d6d6c06b68cbde960542e13501cf833c975f221a012da619f714c57123"
-dependencies = [
- "boxed_error",
- "deno_error 0.5.7",
- "deno_path_util 0.3.3",
- "deno_semver 0.7.1",
- "indexmap",
- "serde",
- "serde_json",
- "sys_traits",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_package_json"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77aee446076be3e2ed9e175b77f423cb20d5d7e1080338f4c77b0b4d290599da"
 dependencies = [
  "boxed_error",
- "deno_error 0.6.1",
- "deno_path_util 0.4.0",
- "deno_semver 0.8.0",
+ "deno_error",
+ "deno_path_util",
+ "deno_semver",
  "indexmap",
  "serde",
  "serde_json",
- "sys_traits",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_path_util"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8850326ea9cb786aafd938f3de9866432904c0bae3aa0139a7a4e570b0174f6"
-dependencies = [
- "deno_error 0.5.7",
- "percent-encoding",
  "sys_traits",
  "thiserror",
  "url",
@@ -788,7 +706,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516f813389095889776b81cc9108ff6f336fd9409b4b12fc0138aea23d2708e1"
 dependencies = [
- "deno_error 0.6.1",
+ "deno_error",
  "percent-encoding",
  "sys_traits",
  "thiserror",
@@ -800,8 +718,8 @@ name = "deno_permissions"
 version = "0.65.0"
 dependencies = [
  "capacity_builder",
- "deno_error 0.6.1",
- "deno_path_util 0.4.0",
+ "deno_error",
+ "deno_path_util",
  "deno_terminal",
  "deno_unsync",
  "fqdn",
@@ -832,22 +750,22 @@ dependencies = [
  "boxed_error",
  "dashmap",
  "deno_cache_dir",
- "deno_config 0.55.0",
- "deno_error 0.6.1",
+ "deno_config",
+ "deno_error",
  "deno_graph",
  "deno_lockfile",
  "deno_media_type",
  "deno_npm",
- "deno_package_json 0.7.0",
- "deno_path_util 0.4.0",
+ "deno_package_json",
+ "deno_path_util",
  "deno_permissions",
- "deno_semver 0.8.0",
+ "deno_semver",
  "deno_terminal",
  "deno_unsync",
  "dissimilar",
  "futures",
  "http",
- "import_map 0.22.0",
+ "import_map",
  "indexmap",
  "log",
  "node_resolver",
@@ -862,29 +780,12 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4775271f9b5602482698f76d24ea9ed8ba27af7f587a7e9a876916300c542435"
-dependencies = [
- "capacity_builder",
- "deno_error 0.5.7",
- "ecow",
- "hipstr",
- "monch",
- "once_cell",
- "serde",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_semver"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d807160e754edb1989b4a19cac1ac5299065a7a89ff98682a2366cbaa25795"
 dependencies = [
  "capacity_builder",
- "deno_error 0.6.1",
+ "deno_error",
  "ecow",
  "hipstr",
  "monch",
@@ -1412,29 +1313,12 @@ dependencies = [
 
 [[package]]
 name = "import_map"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1215d4d92511fbbdaea50e750e91f2429598ef817f02b579158e92803b52c00a"
-dependencies = [
- "boxed_error",
- "deno_error 0.5.7",
- "indexmap",
- "log",
- "percent-encoding",
- "serde",
- "serde_json",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "import_map"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f315e535cb94a0e80704278d630990bb48834c8c8d976acf0a2f6bc8fede7c38"
 dependencies = [
  "boxed_error",
- "deno_error 0.6.1",
+ "deno_error",
  "indexmap",
  "log",
  "percent-encoding",
@@ -1646,13 +1530,13 @@ dependencies = [
  "async-trait",
  "boxed_error",
  "dashmap",
- "deno_config 0.55.0",
- "deno_error 0.6.1",
+ "deno_config",
+ "deno_error",
  "deno_graph",
  "deno_media_type",
- "deno_package_json 0.7.0",
- "deno_path_util 0.4.0",
- "deno_semver 0.8.0",
+ "deno_package_json",
+ "deno_path_util",
+ "deno_semver",
  "futures",
  "lazy-regex",
  "once_cell",
@@ -1939,14 +1823,14 @@ dependencies = [
  "async-trait",
  "console_error_panic_hook",
  "deno_cache_dir",
- "deno_config 0.54.2",
- "deno_error 0.6.1",
+ "deno_config",
+ "deno_error",
  "deno_graph",
  "deno_npm_cache",
  "deno_npm_installer",
- "deno_path_util 0.3.3",
+ "deno_path_util",
  "deno_resolver",
- "deno_semver 0.8.0",
+ "deno_semver",
  "deno_unsync",
  "js-sys",
  "node_resolver",
@@ -2820,7 +2704,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51cf5f08b357e64cd7642ab4bbeb11aecab9e15520692129624fb9908b8df2c"
 dependencies = [
- "deno_error 0.6.1",
+ "deno_error",
  "thiserror",
 ]
 

--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -2,7 +2,9 @@ import { DenoWorkspace, MediaType, ResolutionMode } from "./mod.ts";
 import { assert, assertEquals } from "@std/assert";
 
 Deno.test("should resolve and load", async () => {
-  const workspace = new DenoWorkspace();
+  const workspace = new DenoWorkspace({
+    nodeConditions: undefined, // unsure doesn't error
+  });
   const modFileUrl = import.meta.resolve("./mod.ts");
   const loader = await workspace.createLoader({
     entrypoints: [modFileUrl],

--- a/src/rs_lib/Cargo.toml
+++ b/src/rs_lib/Cargo.toml
@@ -17,12 +17,12 @@ wasm-bindgen = "=0.2.100"
 wasm-bindgen-futures = "=0.4.50"
 async-trait = "0.1.88"
 deno_cache_dir = { version = "0.22.2", features = ["sync"] }
-deno_config = { version = "0.54.2", features = ["workspace", "sync"] }
-deno_error = "0.6.0"
+deno_config = { version = "0.56.0", features = ["workspace", "sync"] }
+deno_error = "0.6.1"
 deno_graph = { version = "0.95.1", features = ["swc"], default-features = false }
 deno_npm_cache = { path = "../../../deno/resolvers/npm_cache" }
 deno_npm_installer = { path = "../../../deno/resolvers/npm_installer", default-features = false }
-deno_path_util = "0.3.3"
+deno_path_util = "0.4.0"
 deno_resolver = { path = "../../../deno/resolvers/deno", features = ["graph", "sync"] }
 deno_semver = "0.8.0"
 deno_unsync = { version = "0.4.4", default-features = false }


### PR DESCRIPTION
This:

```ts
import { DenoWorkspace } from "@deno/loader";

const workspace = new DenoWorkspace({
  nodeConditions: undefined,
});
```

Was erroring:

```
error: Uncaught (in promise) Error: TypeError: Reflect.get called on non-object
  const ret = new Error(getStringFromWasm0(arg0, arg1));
              ^
    at __wbindgen_error_new (https://jsr.io/@deno/loader/0.0.7/src/lib/rs_lib.internal.js:982:15)
    at <anonymous> (wasm://wasm/00fd13ae:1:3222054)
    at <anonymous> (wasm://wasm/00fd13ae:1:3084942)
    at <anonymous> (wasm://wasm/00fd13ae:1:3154713)
    at new DenoWorkspace (https://jsr.io/@deno/loader/0.0.7/src/lib/rs_lib.internal.js:378:22)
    at new DenoWorkspace (https://jsr.io/@deno/loader/0.0.7/src/mod.ts:129:19)
    at file:///Users/marvinh/dev/denoland/esbuild-plugin-deno/foo.ts:3:19
```