### PR TITLE
feat: support bytes and text imports

### DIFF
--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -1,4 +1,9 @@
-import { MediaType, ResolutionMode, Workspace } from "./mod.ts";
+import {
+  MediaType,
+  RequestedModuleType,
+  ResolutionMode,
+  Workspace,
+} from "./mod.ts";
 import { assert, assertEquals } from "@std/assert";
 
 Deno.test("should resolve and load", async () => {
@@ -16,7 +21,10 @@ Deno.test("should resolve and load", async () => {
   );
   assertEquals(resolvedUrl, import.meta.url);
   {
-    const loadResponse = await loader.load(import.meta.url);
+    const loadResponse = await loader.load(
+      import.meta.url,
+      RequestedModuleType.Default,
+    );
     if (loadResponse.kind !== "module") {
       throw new Error("Fail");
     }
@@ -26,7 +34,10 @@ Deno.test("should resolve and load", async () => {
   }
   // node: specifier
   {
-    const loadResponse = await loader.load("node:events");
+    const loadResponse = await loader.load(
+      "node:events",
+      RequestedModuleType.Default,
+    );
     if (loadResponse.kind !== "external") {
       throw new Error("Fail");
     }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { Workspace, ResolutionMode, type LoadResponse } from "@deno/loader";
+ * import { Workspace, ResolutionMode, type LoadResponse, RequestedModuleType } from "@deno/loader";
  *
  * const workspace = new Workspace({
  *   // optional options
@@ -18,7 +18,7 @@
  *   "https://deno.land/mod.ts", // referrer
  *   ResolutionMode.Import,
  * );
- * const response = await loader.load(resolvedUrl);
+ * const response = await loader.load(resolvedUrl, RequestedModuleType.Default);
  * if (response.kind === "module") {
  *   console.log(response.specifier);
  *   console.log(response.code);

--- a/src/rs_lib/Cargo.lock
+++ b/src/rs_lib/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f883bd8eae4dfc8019d925ec3dd04b634b6af9346a5168acc259d55f5f5021d"
+checksum = "0ced09fdb8884e29716cc0691e8510f9c655762bbb9da3111dacc0a2ef6e8960"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -510,8 +510,6 @@ dependencies = [
  "indexmap",
  "jsonc-parser",
  "log",
- "percent-encoding",
- "phf",
  "serde",
  "serde_json",
  "sys_traits",
@@ -625,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "deno_npm_cache"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -654,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "deno_npm_installer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -692,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "deno_package_json"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "boxed_error",
  "deno_error",
@@ -721,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "capacity_builder",
  "deno_error",
@@ -748,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "deno_resolver"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -780,6 +778,7 @@ dependencies = [
  "node_resolver",
  "once_cell",
  "parking_lot",
+ "phf",
  "serde",
  "serde_json",
  "sys_traits",
@@ -1549,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "node_resolver"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/rs_lib/Cargo.toml
+++ b/src/rs_lib/Cargo.toml
@@ -23,7 +23,7 @@ deno_semver = "=0.8.1"
 url = "2.5"
 
 [dependencies.deno_ast]
-version = "=0.48.0"
+version = "=0.48.1"
 features = ["transpiling"]
 
 [dependencies.deno_cache_dir]

--- a/tests/bytes_and_text/main.test.ts
+++ b/tests/bytes_and_text/main.test.ts
@@ -1,0 +1,32 @@
+import {
+  assertResponseText,
+  createLoader,
+  RequestedModuleType,
+  ResolutionMode,
+  type WorkspaceOptions,
+} from "../helpers.ts";
+
+Deno.test("loads jsx transpiled", async () => {
+  const mainTs = import.meta.dirname + "/testdata/main.ts";
+  const createWorkspace = async (options?: WorkspaceOptions) => {
+    return await createLoader({
+      configPath: import.meta.dirname + "/testdata/deno.json",
+      ...(options ?? {}),
+    }, {
+      entrypoints: [mainTs],
+    });
+  };
+  const { loader } = await createWorkspace();
+
+  const mainTsUrl = loader.resolve(mainTs, undefined, ResolutionMode.Import);
+  const dataFileUrl = loader.resolve(
+    "./data_utf8_bom.txt",
+    mainTsUrl,
+    ResolutionMode.Import,
+  );
+
+  assertResponseText(
+    await loader.load(dataFileUrl, RequestedModuleType.Text),
+    `Hello there!`,
+  );
+});

--- a/tests/bytes_and_text/testdata/data_utf8_bom.txt
+++ b/tests/bytes_and_text/testdata/data_utf8_bom.txt
@@ -1,0 +1,1 @@
+﻿Hello there!

--- a/tests/bytes_and_text/testdata/deno.json
+++ b/tests/bytes_and_text/testdata/deno.json
@@ -1,0 +1,5 @@
+{
+  "unstable": [
+    "raw-imports"
+  ]
+}

--- a/tests/bytes_and_text/testdata/main.ts
+++ b/tests/bytes_and_text/testdata/main.ts
@@ -1,0 +1,5 @@
+import dataBytes from "./data_utf8_bom.txt" with { type: "bytes" };
+import dataText from "./data_utf8_bom.txt" with { type: "text" };
+
+console.log(dataBytes);
+console.log(dataText);

--- a/tests/http_no_ext.test.ts
+++ b/tests/http_no_ext.test.ts
@@ -1,4 +1,8 @@
-import { assertResponseText, createLoader } from "./helpers.ts";
+import {
+  assertResponseText,
+  createLoader,
+  RequestedModuleType,
+} from "./helpers.ts";
 
 Deno.test("loads from http server", async () => {
   await using server = Deno.serve((_request) => {
@@ -14,7 +18,7 @@ Deno.test("loads from http server", async () => {
     entrypoints: [url],
   });
 
-  const response = await loader.load(url);
+  const response = await loader.load(url, RequestedModuleType.Default);
   assertResponseText(
     response,
     `console.log(1);`,

--- a/tests/jsx/main.test.ts
+++ b/tests/jsx/main.test.ts
@@ -1,18 +1,24 @@
 import {
   assertResponseText,
   createLoader,
+  RequestedModuleType,
   ResolutionMode,
+  type WorkspaceOptions,
 } from "../helpers.ts";
 import { assert } from "@std/assert";
 
 Deno.test("loads jsx transpiled", async () => {
   const mainJsx = import.meta.dirname + "/testdata/main.jsx";
   const mainTsx = import.meta.dirname + "/testdata/main.tsx";
-  const { loader, workspace } = await createLoader({
-    configPath: import.meta.dirname + "/testdata/deno.json",
-  }, {
-    entrypoints: [mainJsx],
-  });
+  const createWorkspace = async (options?: WorkspaceOptions) => {
+    return await createLoader({
+      configPath: import.meta.dirname + "/testdata/deno.json",
+      ...(options ?? {}),
+    }, {
+      entrypoints: [mainJsx],
+    });
+  };
+  const { loader } = await createWorkspace();
 
   const mainJsxSourceMappingURL =
     "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1haW4uanN4Il0sInNvdXJjZXNDb250ZW50IjpbImNvbnNvbGUubG9nKDxkaXYgLz4pO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7QUFBQSxRQUFRLEdBQUcifQ==";
@@ -22,7 +28,7 @@ Deno.test("loads jsx transpiled", async () => {
   const mainTsxUrl = loader.resolve(mainTsx, undefined, ResolutionMode.Import);
 
   assertResponseText(
-    await loader.load(mainJsxUrl),
+    await loader.load(mainJsxUrl, RequestedModuleType.Default),
     `import { jsxTemplate as _jsxTemplate } from "react/jsx-runtime";
 const $$_tpl_1 = [
   "<div></div>"
@@ -40,30 +46,30 @@ ${mainJsxSourceMappingURL}`,
   assert(jsx.startsWith("file:"));
 
   {
+    const { workspace } = await createWorkspace({ preserveJsx: true });
     const newLoader = await workspace.createLoader({
       entrypoints: [mainJsx, mainTsxUrl],
-      preserveJsx: true,
     });
     assertResponseText(
-      await newLoader.load(mainJsxUrl),
+      await newLoader.load(mainJsxUrl, RequestedModuleType.Default),
       "console.log(<div />);\n",
     );
     assertResponseText(
-      await newLoader.load(mainTsxUrl),
+      await newLoader.load(mainTsxUrl, RequestedModuleType.Default),
       `const value = "";\nconsole.log(<div/>, value);\n${mainTsxSourceMappingURL}`,
     );
   }
   {
+    const { workspace } = await createWorkspace({ noTranspile: true });
     const newLoader = await workspace.createLoader({
       entrypoints: [mainJsx, mainTsx],
-      noTranspile: true,
     });
     assertResponseText(
-      await newLoader.load(mainJsxUrl),
+      await newLoader.load(mainJsxUrl, RequestedModuleType.Default),
       `console.log(<div />);\n`,
     );
     assertResponseText(
-      await newLoader.load(mainTsxUrl),
+      await newLoader.load(mainTsxUrl, RequestedModuleType.Default),
       `const value: string = "";\nconsole.log(<div />, value);\n`,
     );
   }

--- a/tests/link_jsr_entrypoint/main.test.ts
+++ b/tests/link_jsr_entrypoint/main.test.ts
@@ -1,6 +1,7 @@
 import {
   assertResponseText,
   createLoader,
+  RequestedModuleType,
   ResolutionMode,
 } from "../helpers.ts";
 
@@ -14,6 +15,7 @@ Deno.test("loads linked entrypoint", async () => {
 
   const response = await loader.load(
     loader.resolve("@denotest/add", undefined, ResolutionMode.Import),
+    RequestedModuleType.Default,
   );
   assertResponseText(
     response,


### PR DESCRIPTION
`load` now takes a `RequestedModuleType`:

```ts
const javascript = await loader.load(resolvedUrl, RequestedModuleType.Default);
const bytes = await loader.load(resolvedUrl, RequestedModuleType.Bytes);
const text = await loader.load(resolvedUrl, RequestedModuleType.Text);
```

Closes https://github.com/denoland/deno-js-loader/issues/14