### PR TITLE
chore: fix readme doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Resolver and loader for Deno code.
 This can be used to create bundler plugins or libraries that use deno
 resolution.
 
-[Docs](https://jsr.io/badges/@deno/loader)
+[Docs](https://jsr.io/@deno/loader/doc)


### PR DESCRIPTION
Noticed that the "Docs" link in the `README.md` file is wrong.