### PR TITLE
refactor(BREAKING): remove entrypoints option

### DIFF
--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -11,9 +11,8 @@ Deno.test("should resolve, load and get graph", async () => {
     nodeConditions: undefined, // ensure doesn't error
   });
   const modFileUrl = import.meta.resolve("./mod.ts");
-  const { loader, diagnostics } = await workspace.createLoader({
-    entrypoints: [modFileUrl],
-  });
+  const loader = await workspace.createLoader();
+  const diagnostics = await loader.addEntrypoints([modFileUrl]);
   assertEquals(diagnostics.length, 0);
   const graph = loader.getGraphUnstable();
   assertEquals((graph as any).roots[0], modFileUrl);
@@ -52,9 +51,8 @@ Deno.test("should resolve, load and get graph", async () => {
 Deno.test("resolving a jsr specifier should fail with explanatory message", async () => {
   const workspace = new Workspace({});
   const modFileUrl = import.meta.resolve("./mod.ts");
-  const { loader, diagnostics } = await workspace.createLoader({
-    entrypoints: [modFileUrl],
-  });
+  const loader = await workspace.createLoader();
+  const diagnostics = await loader.addEntrypoints([modFileUrl]);
   assertEquals(diagnostics.length, 0);
   assertRejects(
     async () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,4 @@
 import {
-  type LoaderOptions,
   type LoadResponse,
   type ModuleLoadResponse,
   Workspace,
@@ -11,7 +10,7 @@ export * from "@deno/loader";
 
 export async function createLoader(
   workspaceOptions: WorkspaceOptions,
-  loaderOptions: LoaderOptions,
+  loaderOptions: { entrypoints: string[] },
 ) {
   const { loader, workspace, diagnostics } = await createLoaderWithDiagnostics(
     workspaceOptions,
@@ -26,10 +25,11 @@ export async function createLoader(
 
 export async function createLoaderWithDiagnostics(
   workspaceOptions: WorkspaceOptions,
-  loaderOptions: LoaderOptions,
+  loaderOptions: { entrypoints: string[] },
 ) {
   const workspace = new Workspace(workspaceOptions);
-  const { loader, diagnostics } = await workspace.createLoader(loaderOptions);
+  const loader = await workspace.createLoader();
+  const diagnostics = await loader.addEntrypoints(loaderOptions.entrypoints);
   return {
     loader,
     workspace,

--- a/tests/jsx/main.test.ts
+++ b/tests/jsx/main.test.ts
@@ -55,9 +55,8 @@ ${mainJsxSourceMappingURL}`,
 
   {
     const { workspace } = await createWorkspace({ preserveJsx: true });
-    const { loader: newLoader, diagnostics } = await workspace.createLoader({
-      entrypoints: [mainJsx, mainTsxUrl],
-    });
+    const newLoader = await workspace.createLoader();
+    const diagnostics = await newLoader.addEntrypoints([mainJsx, mainTsxUrl]);
     assertEquals(diagnostics, []);
     assertResponseText(
       await newLoader.load(mainJsxUrl, RequestedModuleType.Default),
@@ -70,9 +69,8 @@ ${mainJsxSourceMappingURL}`,
   }
   {
     const { workspace } = await createWorkspace({ noTranspile: true });
-    const { loader: newLoader, diagnostics } = await workspace.createLoader({
-      entrypoints: [mainJsx, mainTsx],
-    });
+    const newLoader = await workspace.createLoader();
+    const diagnostics = await newLoader.addEntrypoints([mainJsx, mainTsx]);
     assertEquals(diagnostics, []);
     assertResponseText(
       await newLoader.load(mainJsxUrl, RequestedModuleType.Default),


### PR DESCRIPTION
Do this now:

```ts
const loader = await workspace.createLoader();
const diagnostics = await loader.addEntrypoints(...);
```